### PR TITLE
Fix missing level scoring parameters

### DIFF
--- a/game.js
+++ b/game.js
@@ -603,12 +603,18 @@ class Soldier {
 }
 
 class Level {
-    constructor(platforms, playerStart, nextLevelPos, keyPosition) {
+    constructor(platforms, playerStart, nextLevelPos, keyPosition,
+                pointsForKey = 100, pointsForCompletion = 200, timeBonus = 100) {
         this.platforms = platforms;
         this.playerStart = playerStart;
         this.nextLevelPos = nextLevelPos;
         this.key = new Key(keyPosition.x, keyPosition.y);
         this.key.visible = true;
+
+        // Scoring parameters
+        this.pointsForKey = pointsForKey;
+        this.pointsForCompletion = pointsForCompletion;
+        this.timeBonus = timeBonus;
         
         // Door image
         this.doorImage = new Image();


### PR DESCRIPTION
## Summary
- define scoring parameters in `Level` objects

## Testing
- `node -c game.js`

------
https://chatgpt.com/codex/tasks/task_e_6859259c49bc8325a87a86b60bfa674d